### PR TITLE
Added Outfunnel under "SAAS Many-to-many"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ WIP curated list of integration tools
 * https://www.piesync.com
 * https://www.informatica.com enterprise
 * https://www.novamodule.com
+* https://outfunnel.com
 
 ## Hosted many-to-many SAAS
 


### PR DESCRIPTION
Hi @iloveitaly, would you mind adding Outfunnel to the list? Outfunnel keeps CRM-s like Hubspot, Pipedrive, Salesforce but also Airtable in sync with marketing data so sales can focus on selling and marketing can deliver results.

Also, PieSync that's listed here as well got acquired by HubSpot and is being shut down soon.